### PR TITLE
下書き機能の実装

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,4 +1,8 @@
 class Article < ApplicationRecord
+  enum status: {
+    draft: 0, published: 1
+  }
+
   belongs_to :user
 
   validates :title, presence: true, uniqueness: true, length: { maximum: 64 }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -1,6 +1,6 @@
 class Article < ApplicationRecord
   enum status: {
-    draft: 0, published: 1
+    draft: "draft", published: "published"
   }
 
   belongs_to :user

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,11 +3,11 @@
 Rails.application.routes.draw do
   root "homes#index"
 
-   # reload 対策
-   get "sign_up", to: "homes#index"
-   get "sign_in", to: "homes#index"
-   get "articles/new", to: "homes#index"
-   get "articles/:id", to: "homes#index"
+  # reload 対策
+  get "sign_up", to: "homes#index"
+  get "sign_in", to: "homes#index"
+  get "articles/new", to: "homes#index"
+  get "articles/:id", to: "homes#index"
 
   namespace :api do
     namespace :v1 do

--- a/db/migrate/20200106122826_add_status_to_articles.rb
+++ b/db/migrate/20200106122826_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[5.2]
+  def change
+    add_column :articles, :status, :integer
+  end
+end

--- a/db/migrate/20200106124651_change_column_to_article.rb
+++ b/db/migrate/20200106124651_change_column_to_article.rb
@@ -1,0 +1,9 @@
+class ChangeColumnToArticle < ActiveRecord::Migration[5.2]
+  def up
+    change_column :articles, :status, :integer, null: false, default: 0, limit: 1
+  end
+
+  def down
+    change_column :articles, :status, :integer
+  end
+end

--- a/db/migrate/20200108124003_change_column_string_to_article.rb
+++ b/db/migrate/20200108124003_change_column_string_to_article.rb
@@ -1,0 +1,9 @@
+class ChangeColumnStringToArticle < ActiveRecord::Migration[5.2]
+  def up
+    change_column :articles, :status, :string, null: false, default: "draft"
+  end
+
+  def down
+    change_column :articles, :status, :integer, null: false, default: 0, limit: 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_06_124651) do
+ActiveRecord::Schema.define(version: 2020_01_08_124003) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "article_id"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 2020_01_06_124651) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "status", limit: 1, default: 0, null: false
+    t.string "status", default: "draft", null: false
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_28_211613) do
+ActiveRecord::Schema.define(version: 2020_01_06_124651) do
 
   create_table "article_likes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "article_id"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2019_09_28_211613) do
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", limit: 1, default: 0, null: false
   end
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -3,9 +3,14 @@ FactoryBot.define do
     title { Faker::Lorem.characters(number: Random.new.rand(1..64)) }
     body { Faker::Lorem.characters }
     user
+    status { :draft }
 
     trait :with_comment do
       comment
+    end
+
+    trait :published do
+      status { :published }
     end
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :published do
       status { :published }
     end
+
+    trait :draft do
+      status { :draft }
+    end
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Article, type: :model do
     it "下書きとして記事が有効である" do
       expect(article).to be_valid
       expect(article.status).to eq "draft"
-      expect { article.save! }.to change { Article.where(status: "draft").count }.by(1)
+      expect { article.save! }.to change { Article.draft.count }.by(1)
     end
   end
 
@@ -17,7 +17,7 @@ RSpec.describe Article, type: :model do
     it "公開記事として有効である" do
       expect(article).to be_valid
       expect(article.status).to eq "published"
-      expect { article.save! }.to change { Article.where(status: "published").count }.by(1)
+      expect { article.save! }.to change { Article.published.count }.by(1)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -43,6 +43,8 @@ RSpec.describe Article, type: :model do
 end
 
 describe "#draft" do
+  subject { Article.draft }
+
   before do
     create_list(:article, 10)
   end
@@ -53,6 +55,8 @@ describe "#draft" do
 end
 
 describe "#published" do
+  subject { Article.published }
+
   before do
     create_list(:article, 10, :published)
   end
@@ -63,6 +67,8 @@ describe "#published" do
 end
 
 describe "#status" do
+  subject { article.status }
+
   context "statusがdraftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -81,6 +87,8 @@ describe "#status" do
 end
 
 describe "#draft?" do
+  subject { article.draft? }
+
   context "statusがdraftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -99,6 +107,8 @@ describe "#draft?" do
 end
 
 describe "#published?" do
+  subject { article.published? }
+
   context "draftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -117,6 +127,8 @@ describe "#published?" do
 end
 
 describe "#published!" do
+  subject { article.published! }
+
   context "draftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -128,6 +140,8 @@ describe "#published!" do
 end
 
 describe "#draft!" do
+  subject { article.draft! }
+
   context "publishedのとき" do
     let(:article) { create(:article, :published) }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -5,10 +5,9 @@ RSpec.describe Article, type: :model do
     let(:article) { build(:article) }
 
     it "下書きとして記事が有効である" do
-      binding.pry
       expect(article).to be_valid
       expect(article.status).to eq "draft"
-      expect{ article.save! }.to change{ Article.where(status: "draft").count }.by(1)
+      expect { article.save! }.to change { Article.where(status: "draft").count }.by(1)
     end
   end
 
@@ -18,7 +17,7 @@ RSpec.describe Article, type: :model do
     it "公開記事として有効である" do
       expect(article).to be_valid
       expect(article.status).to eq "published"
-      expect{ article.save! }.to change{ Article.where(status: "published").count }.by(1)
+      expect { article.save! }.to change { Article.where(status: "published").count }.by(1)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,41 +1,43 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  context "正常系(statusの指定がないとき)" do
-    let(:article) { build(:article) }
+  describe "validation check" do
+    context "正常系(statusの指定がないとき)" do
+      let(:article) { build(:article) }
 
-    it "下書きとして記事が有効である" do
-      expect(article).to be_valid
-      expect(article.status).to eq "draft"
-      expect { article.save! }.to change { Article.draft.count }.by(1)
+      it "下書きとして記事が有効である" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+        expect { article.save! }.to change { Article.draft.count }.by(1)
+      end
     end
-  end
 
-  context "正常系（statusがpublishedのとき）" do
-    let(:article) { build(:article, status: "published") }
+    context "正常系（statusがpublishedのとき）" do
+      let(:article) { build(:article, status: "published") }
 
-    it "公開記事として有効である" do
-      expect(article).to be_valid
-      expect(article.status).to eq "published"
-      expect { article.save! }.to change { Article.published.count }.by(1)
+      it "公開記事として有効である" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+        expect { article.save! }.to change { Article.published.count }.by(1)
+      end
     end
-  end
 
-  context "titleがないとき" do
-    let(:article) { build(:article, title: nil) }
+    context "titleがないとき" do
+      let(:article) { build(:article, title: nil) }
 
-    it "エラーする" do
-      article.valid?
-      expect(article.errors.messages[:title]).to include "can't be blank"
+      it "エラーする" do
+        article.valid?
+        expect(article.errors.messages[:title]).to include "can't be blank"
+      end
     end
-  end
 
-  context "titleが長すぎるとき" do
-    let(:article) { build(:article, title: Faker::Lorem.characters(number: Random.new.rand(65..999))) }
+    context "titleが長すぎるとき" do
+      let(:article) { build(:article, title: Faker::Lorem.characters(number: Random.new.rand(65..999))) }
 
-    it "エラーする" do
-      article.valid?
-      expect(article.errors.messages[:title]).to include "is too long (maximum is 64 characters)"
+      it "エラーする" do
+        article.valid?
+        expect(article.errors.messages[:title]).to include "is too long (maximum is 64 characters)"
+      end
     end
   end
 end
@@ -62,7 +64,7 @@ end
 
 
 
-describe "#.status" do
+describe "#status" do
   context "statusがdraftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -80,7 +82,7 @@ describe "#.status" do
   end
 end
 
-describe "#.draft?" do
+describe "#draft?" do
   context "statusがdraftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -98,7 +100,7 @@ describe "#.draft?" do
   end
 end
 
-describe "#.published?" do
+describe "#published?" do
   context "draftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -116,7 +118,7 @@ describe "#.published?" do
   end
 end
 
-describe "#.published!" do
+describe "#published!" do
   context "draftのとき" do
     let(:article) { create(:article, :draft) }
 
@@ -127,7 +129,7 @@ describe "#.published!" do
   end
 end
 
-describe "#.draft!" do
+describe "#draft!" do
   context "publishedのとき" do
     let(:article) { create(:article, :published) }
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -54,15 +54,13 @@ end
 
 describe "#published" do
   before do
-    create_list(:article, 10 ,:published)
+    create_list(:article, 10, :published)
   end
 
   it "publishedの検索ができる" do
     expect(Article.published).to eq Article.where(status: "published")
   end
 end
-
-
 
 describe "#status" do
   context "statusがdraftのとき" do
@@ -110,11 +108,11 @@ describe "#published?" do
   end
 
   context "publishedのとき" do
-      let(:article) { create(:article, :published) }
+    let(:article) { create(:article, :published) }
 
-      it "true" do
-        expect(article.published?).to eq true
-      end
+    it "true" do
+      expect(article.published?).to eq true
+    end
   end
 end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -1,11 +1,24 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  context "正常系" do
+  context "正常系(statusの指定がないとき)" do
     let(:article) { build(:article) }
 
-    it "記事が有効である" do
+    it "下書きとして記事が有効である" do
+      binding.pry
       expect(article).to be_valid
+      expect(article.status).to eq "draft"
+      expect{ article.save! }.to change{ Article.where(status: "draft").count }.by(1)
+    end
+  end
+
+  context "正常系（statusがpubrishedのとき）" do
+    let(:article) { build(:article, status: "published") }
+
+    it "公開記事として有効である" do
+      expect(article).to be_valid
+      expect(article.status).to eq "published"
+      expect{ article.save! }.to change{ Article.where(status: "published").count }.by(1)
     end
   end
 

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Article, type: :model do
     end
   end
 
-  context "正常系（statusがpubrishedのとき）" do
+  context "正常系（statusがpublishedのとき）" do
     let(:article) { build(:article, status: "published") }
 
     it "公開記事として有効である" do
@@ -36,6 +36,104 @@ RSpec.describe Article, type: :model do
     it "エラーする" do
       article.valid?
       expect(article.errors.messages[:title]).to include "is too long (maximum is 64 characters)"
+    end
+  end
+end
+
+describe "#draft" do
+  before do
+    create_list(:article, 10)
+  end
+
+  it "draftの検索ができる" do
+    expect(Article.draft).to eq Article.where(status: "draft")
+  end
+end
+
+describe "#published" do
+  before do
+    create_list(:article, 10 ,:published)
+  end
+
+  it "publishedの検索ができる" do
+    expect(Article.published).to eq Article.where(status: "published")
+  end
+end
+
+
+
+describe "#.status" do
+  context "statusがdraftのとき" do
+    let(:article) { create(:article, :draft) }
+
+    it "draftが返ってくる" do
+      expect(article.status).to eq "draft"
+    end
+  end
+
+  context "statusがpublishedのとき" do
+    let(:article) { create(:article, :published) }
+
+    it "publishedが返ってくる" do
+      expect(article.status).to eq "published"
+    end
+  end
+end
+
+describe "#.draft?" do
+  context "statusがdraftのとき" do
+    let(:article) { create(:article, :draft) }
+
+    it "trueが返ってくる" do
+      expect(article.draft?).to eq true
+    end
+  end
+
+  context "statusがpublishedのとき" do
+    let(:article) { create(:article, :published) }
+
+    it "false" do
+      expect(article.draft?).to eq false
+    end
+  end
+end
+
+describe "#.published?" do
+  context "draftのとき" do
+    let(:article) { create(:article, :draft) }
+
+    it "false" do
+      expect(article.published?).to eq false
+    end
+  end
+
+  context "publishedのとき" do
+      let(:article) { create(:article, :published) }
+
+      it "true" do
+        expect(article.published?).to eq true
+      end
+  end
+end
+
+describe "#.published!" do
+  context "draftのとき" do
+    let(:article) { create(:article, :draft) }
+
+    it "publishedに更新される" do
+      expect(article.published!).to eq true
+      expect(article[:status]).to eq "published"
+    end
+  end
+end
+
+describe "#.draft!" do
+  context "publishedのとき" do
+    let(:article) { create(:article, :published) }
+
+    it "draftに更新する" do
+      expect(article.draft!).to eq true
+      expect(article[:status]).to eq "draft"
     end
   end
 end

--- a/spec/requests/api/v1/registrations_spec.rb
+++ b/spec/requests/api/v1/registrations_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe "Api::V1::Auth::Registrations", type: :request do
       end
     end
 
-
     context "アカウント名が空のとき" do
       let(:params) { attributes_for(:user, name: nil) }
 


### PR DESCRIPTION
`enum` を利用して記事の下書き機能を追加
以下のように対応しました
ご確認をお願いします

- article table にstatusカラムを追加
- statusカラムに制約を追加
- article modelにenumを追加
- modelテストを修正

1/12追加
- enumに起因するメソッドのテストを実装