### PR TITLE
下書き機能追加によるAPIテストの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -2,12 +2,12 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
   before_action :authenticate_user!, only: [:create, :update, :destroy]
 
   def index
-    articles = Article.all
+    articles = Article.published
     render json: articles
   end
 
   def show
-    article = Article.find(params[:id])
+    article = Article.published.find(params[:id])
     render json: article
   end
 
@@ -29,6 +29,6 @@ class Api::V1::ArticlesController < Api::V1::BaseApiController
    private
 
      def article_params
-       params.require(:article).permit(:title, :body)
+       params.require(:article).permit(:title, :body, :status)
      end
  end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :updated_at, :status
 
   belongs_to :user
 end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -5,27 +5,28 @@ RSpec.describe "Api::V1::Articles", type: :request do
     subject { get(api_v1_articles_path) }
 
     before do
-      create_list(:article, 3)
+      create_list(:article, 10)
+      create_list(:article, 5, :published)
     end
 
-    it "記事の一覧が取得できる" do
+    it "公開済み記事の一覧が取得できる" do
       subject
       res = JSON.parse(response.body)
 
       expect(response).to have_http_status(:ok)
-      expect(res.length).to eq Article.count
-      expect(res[0].keys).to eq ["id", "title", "body", "user"]
+      expect(res.length).to eq Article.published.count
+      expect(res[0].keys).to eq ["id", "title", "body", "updated_at", "status", "user"]
     end
   end
 
   describe "GET /api/v1/articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定したidの記事が存在する場合" do
-      let(:article) { create(:article) }
+    context "指定したidの記事が存在し公開済みの場合" do
+      let(:article) { create(:article, :published) }
       let(:article_id) { article.id }
 
-      it "任意の記事の詳細を表示できる" do
+      it "記事の詳細を表示できる" do
         subject
         res = JSON.parse(response.body)
 
@@ -44,21 +45,47 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
+
+    context "指定した記事が下書き状態の場合" do
+      let(:article) { create(:article, :draft) }
+      let(:article_id) { article.id }
+
+      it "詳細が見れない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
   end
 
   describe "POST /api/v1/articles" do
     subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
     let(:headers) { authenticate_user_headers(current_user) }
 
-    it "新規記事を作成できる" do
-      expect { subject }.to change { current_user.articles.count }.by(1)
-      expect(response).to have_http_status(:ok)
-      res = JSON.parse(response.body)
-      expect(res["title"]).to eq params[:article][:title]
-      expect(res["body"]).to eq params[:article][:body]
+    context "公開済みを選択したとき" do
+      let(:params) { { article: attributes_for(:article, :published) } }
+
+      it "公開記事を作成できる" do
+        expect { subject }.to change { current_user.articles.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "published"
+      end
+    end
+
+    context "下書きを選択したとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+
+      it "下書き記事を作成できる" do
+        expect { subject }.to change { current_user.articles.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "draft"
+      end
     end
   end
 


### PR DESCRIPTION
以下のように修正しました
- Articles_controller で一覧や詳細は公開記事のみ適用されるよう修正
- 記事の作成、更新については『公開記事』と『下書き』を選択できるように修正
- responseのカラムにstatusを含むようにarticle_serializerを加筆
- 上記に伴うAPIテストの修正

`responseのカラムにstatusを含むようにarticle_serializerを加筆`
これが一番手間取りましたが、gemを入れていたことを思い出し、調べ直したりすることで解決できました。本当は一覧機能では、`status`は除くようにしたいと思ったものの（そもそもpublishedの記事のみが一覧に出てくるので）、うまく実装できませんでいした。

rspecに関しては作成の部分で、statusを選択できるようにcontrollerを実装しましたが、テストでは作成された記事のstatusが正しいかどうかだけを確かめるために同じような記述をする部分が多く、最初は 『beforeを使って共通化や』と意気込んだものの、letが弾かれ、『それなら `let`は使わずに変数定義するぞ』と試みたものの失敗して、結局beforeから外すだけというなんとも遠回りなことをして、非常に時間がかかりました。

上記に２箇所で悩みましたが、いずれも以前は曖昧であった部分が繋がってきて『ああ〜なるほど』と思える部分も増え、一層楽しくなってきました。