### PR TITLE
自分の公開記事一覧の記事とテストの実装

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Current::ArticlesController < Api::V1::BaseApiController
+  before_action :authenticate_user!, only: [:index]
+
+  def index
+    articles = current_user.articles.published.order(updated_at: "DESC")
+    render json: articles
+  end
+end

--- a/app/serializers/api/v1/current/article_serializer.rb
+++ b/app/serializers/api/v1/current/article_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::Current::ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+
+  belongs_to :user
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,11 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+
+      namespace :current do
+        resources :articles, only: [:index]
+      end
+
       resources :articles
     end
   end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:current_user) { create(:user) }
+    let(:other_user) { create(:user) }
+    let(:headers) { authenticate_user_headers(current_user) }
+
+    let!(:article1) { create(:article, :draft, user: current_user) }
+    let!(:article2) { create(:article, :published, user: current_user, updated_at: 1.hour.ago) }
+    let!(:article3) { create(:article, :published, user: current_user, updated_at: 2.hour.ago) }
+    let!(:article4) { create(:article, :draft, user: other_user) }
+    let!(:article5) { create(:article, :published, user: current_user, updated_at: 1.day.ago) }
+
+    it "自分の公開記事を一覧として取得できる" do
+      subject
+      res = JSON.parse(response.body)
+      expect(response).to have_http_status(:ok)
+      expect(res.length).to eq current_user.articles.published.count
+      expect(res.map{ |s| s["id"]}).to eq [article2.id, article3.id, article5.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["title"]).to eq article2[:title]
+      expect(res[0]["id"]).to eq article2["id"]
+    end
+  end
+end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
       expect(res.map{ |s| s["id"]}).to eq [article2.id, article3.id, article5.id]
       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
       expect(res[0]["title"]).to eq article2[:title]
-      expect(res[0]["id"]).to eq article2["id"]
+      expect(res[0]["id"]).to eq article2[:id]
     end
   end
 end

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Api::V1::Current::Articles", type: :request do
       res = JSON.parse(response.body)
       expect(response).to have_http_status(:ok)
       expect(res.length).to eq current_user.articles.published.count
-      expect(res.map{ |s| s["id"]}).to eq [article2.id, article3.id, article5.id]
+      expect(res.map {|s| s["id"] }).to eq [article2.id, article3.id, article5.id]
       expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
       expect(res[0]["title"]).to eq article2[:title]
       expect(res[0]["id"]).to eq article2[:id]


### PR DESCRIPTION
以下のように実装しました
- `current/articles_controller` の作成
- ルーティングの修正
- current/articles_serializerを作成し`indexアクション` で返されるカラムの調整
公開記事の一覧なので、`:status` と`:body` は表示されないようにしました
- rspecの実装
『きちんと表示したい記事（自分の公開記事）のみを表示しているか』のテストに`mapメソッド`を採用しました。